### PR TITLE
New method for generating data from account template

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -3,33 +3,32 @@ import { Template } from "../src/template";
 
 const datamaker = new DataMaker({});
 
-const template = {
-  name: "basic template",
-  quantity: 2,
-  fields: [
-    {
-      name: "first_name",
-      type: "First Name",
-    },
-    {
-      name: "last_name",
-      type: "Last Name",
-    },
-    {
-      name: "email",
-      type: "Derived",
-      options: {
-        value: "{{first_name}}.{{last_name}}@automators.com",
+const generateData = async () => {
+  const template = {
+    name: "basic template",
+    quantity: 2,
+    fields: [
+      {
+        name: "first_name",
+        type: "First Name",
       },
-    },
-  ],
-} satisfies Template;
+      {
+        name: "last_name",
+        type: "Last Name",
+      },
+      {
+        name: "email",
+        type: "Derived",
+        options: {
+          value: "{{first_name}}.{{last_name}}@automators.com",
+        },
+      },
+    ],
+  } satisfies Template;
+  
+  const data = await datamaker.generate(template);
+  const result = await data.json();
+  console.log(result);   
+};
 
-datamaker
-  .generate(template)
-  .then((res) => {
-    return res.json();
-  })
-  .then((data) => {
-    console.log(data);
-  });
+generateData();

--- a/examples/fromAccountTemplate.ts
+++ b/examples/fromAccountTemplate.ts
@@ -6,7 +6,7 @@ const datamaker = new DataMaker({});
 const generateData = async () => {
     const quantity = 2;
     const data = await datamaker
-        .generateFromTemplate("templateIDFromYourAccount", quantity)
+        .generateFromTemplateId("templateIDFromYourAccount", quantity)
     const result = await data.json();
   
     console.log(result);    

--- a/examples/fromAccountTemplate.ts
+++ b/examples/fromAccountTemplate.ts
@@ -1,0 +1,15 @@
+// First set your Datamaker api key as DATAMAKER_API_KEY environment variable
+import { DataMaker } from "../src/index";
+
+const datamaker = new DataMaker({});  
+
+const generateData = async () => {
+    const quantity = 2;
+    const data = await datamaker
+        .generateFromTemplate("templateIDFromYourAccount", quantity)
+    const result = await data.json();
+  
+    console.log(result);    
+};
+
+generateData();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -97,16 +97,15 @@ test("Basic data generation", async () => {
   expect(res[0].email).toContain(res[0].first_name);
 });
 
-test('Generate data using new method', async () => {
-  const quantity = 5;
+test('Generate data from template in account', async () => {
+  const quantity = 2;
   const datamaker = new DataMaker({});
-
   const result = await datamaker
-    .generateFromTemplate("Test temp", quantity);
+    .generateFromTemplate("clr0ddsrk0001jr09r5kxkt4a", quantity); 
     
   expect(result.length).toBe(quantity);
   expect(result[0]["First Name"]).toBeDefined();
   expect(result[0]["Last Name"]).toBeDefined();
   expect(result[0]["Age"]).toBeDefined();
-  expect(result[0]["street"]).toBeDefined();
+  expect(result[0]["Street"]).toBeDefined();
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -101,7 +101,7 @@ test('Generate data from template in account', async () => {
   const quantity = 2;
   const datamaker = new DataMaker({});
   const result = await datamaker
-    .generateFromTemplate("clr0ddsrk0001jr09r5kxkt4a", quantity); 
+    .generateFromTemplateId("clr0ddsrk0001jr09r5kxkt4a", quantity); 
     
   expect(result.length).toBe(quantity);
   expect(result[0]["First Name"]).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,3 @@
-import exp from "constants";
 import { DataMaker } from "./index";
 import { expect, test } from "vitest";
 
@@ -89,13 +88,25 @@ test("Basic data generation", async () => {
           },
         },
       ],
-    })
-    .then((res) => res.json())
-    .then((data) => data);
+    });
 
   expect(res.length).toBe(1);
   expect(res[0].first_name).toBeDefined();
   expect(res[0].last_name).toBeDefined();
   expect(res[0].email).toBeDefined();
   expect(res[0].email).toContain(res[0].first_name);
+});
+
+test('Generate data using new method', async () => {
+  const quantity = 5;
+  const datamaker = new DataMaker({});
+
+  const result = await datamaker
+    .generateFromTemplate("Test temp", quantity);
+    
+  expect(result.length).toBe(quantity);
+  expect(result[0]["First Name"]).toBeDefined();
+  expect(result[0]["Last Name"]).toBeDefined();
+  expect(result[0]["Age"]).toBeDefined();
+  expect(result[0]["street"]).toBeDefined();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,14 +117,14 @@ class DataMaker {
     return (await fetchDatamaker(this.options.baseURL, this.headers, template)).json(); 
   };
   /**
-   * Generate data using template from you Datamaker account. Provide with unique name of a template from your account and a number of entries to be generated as arguments.
+   * Generate data using template from you Datamaker account. As arguments provide ID of a template from your account and a number of entries to be generated.
    * Requires Datamaker api key to be defined in your project.
-   * @param templateName 
+   * @param templateId 
    * @param quantity 
    * @returns 
    */
-  async generateFromTemplate(templateName: string, quantity: number = 1) {
-    const url = "https://public.datamaker.app/api/templates";
+  async generateFromTemplate(templateId: string, quantity: number = 1) {        
+    const url = `${this.options.baseURL}/templates`;
     const headers = {
       "Authorization": this.apiKey,
       "Content-type": "application/json",  
@@ -137,7 +137,7 @@ class DataMaker {
     });
 
     const templateData = await fetchTemplate.json();
-    let template = templateData.filter((temp: AccountTemplate) => temp.name === templateName);
+    let template = templateData.filter((temp: AccountTemplate) => temp.id === templateId);
   
     if (!templateData) {
       throw new Errors.DataMakerError(
@@ -147,13 +147,7 @@ class DataMaker {
     
     if (!template) {
       throw new Errors.DataMakerError(
-        "You must provide a name of a template from your account."
-      );
-    };
-
-    if (template.length > 1) {
-      throw new Errors.DataMakerError(
-        "Multiple templates of the same name have been found in your account. Provide with unique template name."
+        "You must provide ID of a template from your account."
       );
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ class DataMaker {
    * @param quantity 
    * @returns 
    */
-  async generateFromTemplate(templateId: string, quantity: number = 1) {        
+  async generateFromTemplateId(templateId: string, quantity: number = 1) {        
     const url = `${this.options.baseURL}/templates`;
     const headers = {
       "Authorization": this.apiKey,

--- a/src/template.ts
+++ b/src/template.ts
@@ -379,3 +379,14 @@ export type Template = {
   fields: Fields;
   quantity?: number;
 };
+
+export type AccountTemplate = {
+  id: string;
+  name: string;
+  fields: Fields;
+  createdAt: string;
+  createdBy: string;
+  templateFolderId: null,
+  teamId: string;
+  seed: null
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { DataMakerError } from "./error";
+import { AccountTemplate, Template } from "./template";
 
 export const sleep = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -95,4 +96,12 @@ export const validatePositiveInteger = (name: string, n: unknown): number => {
     throw new DataMakerError(`${name} must be a positive integer`);
   }
   return n;
+};
+
+export const fetchDatamaker = async (url: string | undefined, headers: HeadersInit, template: Template | AccountTemplate) => {
+  return await fetch(`${url}/datamaker`, {
+    method: "POST",
+    headers: headers,
+    body: JSON.stringify(template),
+  });
 };


### PR DESCRIPTION
- adds new method for generating data defined by template the user has saved in his Datamaker account. 
- adds test for the new method
- makes slight change to the existing .generate() method so that both this and the new method return data in json format, not promise, so the user does not have do the conversion himself
- extracts calling datamaker api to separate function
- adds new types