### PR TITLE
Implemented api export method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,36 +23,35 @@ const datamaker = new DataMaker({
   apiKey: `YOUR_API_KEY`,
 });
 
-const template = {
-  name: "basic template",
-  quantity: 2,
-  fields: [
-    {
-      name: "first_name",
-      type: "First Name",
-    },
-    {
-      name: "last_name",
-      type: "Last Name",
-    },
-    {
-      name: "email",
-      type: "Derived",
-      options: {
-        value: "{{first_name}}.{{last_name}}@automators.com",
+const generateData = async () => {
+  const template = {
+    name: "basic template",
+    quantity: 2,
+    fields: [
+      {
+        name: "first_name",
+        type: "First Name",
       },
-    },
-  ],
-} satisfies Template;
+      {
+        name: "last_name",
+        type: "Last Name",
+      },
+      {
+        name: "email",
+        type: "Derived",
+        options: {
+          value: "{{first_name}}.{{last_name}}@automators.com",
+        },
+      },
+    ],
+  } satisfies Template;
+  
+  const data = await datamaker.generate(template);
+  const result = await data.json();
+  console.log(result);   
+};
 
-datamaker
-  .generate(template)
-  .then((res) => {
-    return res.json();
-  })
-  .then((data) => {
-    console.log(data);
-  });
+generateData();
 ```
 
 ## Development & Contibutions

--- a/examples/exportToApi.ts
+++ b/examples/exportToApi.ts
@@ -1,0 +1,36 @@
+// First set your Datamaker api key as DATAMAKER_API_KEY environment variable
+import { DataMaker, CustomEndpoint } from "../src/index";
+
+const datamaker = new DataMaker({});  
+
+// Generate data and send them to API endpoint saved in your Datamaker account (identified by ID)
+const exportToPredefinedEndpoint = async () => {
+    const quantity = 2;
+    const generate = await datamaker.generateFromTemplateId("templateIDFromYourAccount", quantity);    
+    const data = await generate.json();
+
+    await datamaker.exportToApi("idOfEndpointInYourAccount", data);    
+};
+
+exportToPredefinedEndpoint();
+
+// Generate data and send them to a custom API endpoint
+const exportToCustomEndpoint = async () => {
+    const quantity = 2;
+    // Define endpoint that has obligatory url and method parameters and optional headers parameter
+    const endpoint: CustomEndpoint = {
+        url: "urlOfYourEndpoint",
+        method: "POST",
+        headers: {
+            // optional headers object
+        }
+    };
+
+    const generate = await datamaker.generateFromTemplateId("templateIDFromYourAccount", quantity);    
+    const data = await generate.json();
+
+    // Call export method with your defined endpoint instead of endpoint ID from your Datamaker account
+    await datamaker.exportToApi(endpoint, data);
+};
+
+exportToCustomEndpoint();

--- a/examples/generateFromTemplateId.ts
+++ b/examples/generateFromTemplateId.ts
@@ -5,8 +5,7 @@ const datamaker = new DataMaker({});
 
 const generateData = async () => {
     const quantity = 2;
-    const data = await datamaker
-        .generateFromTemplateId("templateIDFromYourAccount", quantity)
+    const data = await datamaker.generateFromTemplateId("templateIDFromYourAccount", quantity);
     const result = await data.json();
   
     console.log(result);    

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,8 @@
 import { DataMaker } from "./index";
 import { expect, test } from "vitest";
+import { CustomEndpoint, Data } from "./template";
+
+const baseUrl = "https://public.datamaker.app/api/";
 
 test("Test creating an instance ", () => {
   const datamaker = new DataMaker({
@@ -107,5 +110,65 @@ test('Generate data from template in account', async () => {
   expect(result[0]["First Name"]).toBeDefined();
   expect(result[0]["Last Name"]).toBeDefined();
   expect(result[0]["Age"]).toBeDefined();
-  expect(result[0]["Street"]).toBeDefined();
+  expect(result[0]["Street"]).toBeDefined();  
+});
+
+test('Send multiple generated data to API endpoint in account', async () => {
+  const datamaker = new DataMaker({});
+  const headers: any = {
+    "Authorization": process.env["DATAMAKER_API_KEY"],
+    "Content-type": "application/json",  
+    "Credentials": "omit"   
+  };
+  const data = await datamaker.generateFromTemplateId("clr8yxrcy0001l808m70stapk", 3);
+  const result: Data[] = await datamaker.exportToApi(data, "clr8uh27l0001l108cr92wxjo");
+
+  expect(result[0]?.name).toBeDefined();
+  expect(result[0]?.name).equal(data[0].name);
+  expect(result[0]?.connectionString).toBeDefined();
+  expect(result[0]?.connectionString).equal(data[0].connectionString);
+  expect(result[0]?.createdBy).toBeDefined();
+  expect(result[0]?.createdBy).equal(data[0].createdBy);
+  
+  for (const entry of result) {
+    const deleteResult = await fetch(`${baseUrl}connections/${entry.id}`, {
+      method: "DELETE",
+      headers: headers
+    });
+    const deleteData = await deleteResult.json();    
+    expect(deleteData.id).equal(entry.id);
+  };
+});
+
+test('Send generated data to API endpoint defined in code', async () => {
+  const datamaker = new DataMaker({});
+  const headers: any = {
+    "Authorization": process.env["DATAMAKER_API_KEY"],
+    "Content-type": "application/json",  
+    "Credentials": "omit"   
+  };
+  const endpoint: CustomEndpoint = {
+    method: "POST",
+    url: `${baseUrl}connections`,
+    headers: headers
+  };
+
+  const data = await datamaker.generateFromTemplateId("clr8yxrcy0001l808m70stapk", 4);
+  const result: Data[] = await datamaker.exportToApi(data, endpoint);
+
+  expect(result[0]?.name).toBeDefined();
+  expect(result[0]?.name).equal(data[0].name);
+  expect(result[0]?.connectionString).toBeDefined();
+  expect(result[0]?.connectionString).equal(data[0].connectionString);
+  expect(result[0]?.createdBy).toBeDefined();
+  expect(result[0]?.createdBy).equal(data[0].createdBy);
+  
+  for (const entry of result) {
+    const deleteResult = await fetch(`${baseUrl}connections/${entry.id}`, {
+      method: "DELETE",
+      headers: headers
+    });
+    const deleteData = await deleteResult.json();    
+    expect(deleteData.id).equal(entry.id);
+  };
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -113,7 +113,7 @@ test('Generate data from template in account', async () => {
   expect(result[0]["Street"]).toBeDefined();  
 });
 
-test('Send multiple generated data to API endpoint in account', async () => {
+test('Send multiple generated data to API endpoint from account', async () => {
   const datamaker = new DataMaker({});
   const headers: any = {
     "Authorization": process.env["DATAMAKER_API_KEY"],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,7 @@ import { DataMaker } from "./index";
 import { expect, test } from "vitest";
 import { CustomEndpoint, Data } from "./template";
 
-const baseUrl = "https://public.datamaker.app/api/";
+const baseUrl = "https://public.datamaker.app/api";
 
 test("Test creating an instance ", () => {
   const datamaker = new DataMaker({
@@ -120,8 +120,8 @@ test('Send multiple generated data to API endpoint in account', async () => {
     "Content-type": "application/json",  
     "Credentials": "omit"   
   };
-  const data = await datamaker.generateFromTemplateId("clr8yxrcy0001l808m70stapk", 3);
-  const result: Data[] = await datamaker.exportToApi(data, "clr8uh27l0001l108cr92wxjo");
+  const data = await datamaker.generateFromTemplateId("clr8yxrcy0001l808m70stapk", 2);
+  const result: Data[] = await datamaker.exportToApi("clr8uh27l0001l108cr92wxjo", data);
 
   expect(result[0]?.name).toBeDefined();
   expect(result[0]?.name).equal(data[0].name);
@@ -131,7 +131,7 @@ test('Send multiple generated data to API endpoint in account', async () => {
   expect(result[0]?.createdBy).equal(data[0].createdBy);
   
   for (const entry of result) {
-    const deleteResult = await fetch(`${baseUrl}connections/${entry.id}`, {
+    const deleteResult = await fetch(`${baseUrl}/connections/${entry.id}`, {
       method: "DELETE",
       headers: headers
     });
@@ -149,12 +149,12 @@ test('Send generated data to API endpoint defined in code', async () => {
   };
   const endpoint: CustomEndpoint = {
     method: "POST",
-    url: `${baseUrl}connections`,
+    url: `${baseUrl}/connections`,
     headers: headers
   };
 
-  const data = await datamaker.generateFromTemplateId("clr8yxrcy0001l808m70stapk", 4);
-  const result: Data[] = await datamaker.exportToApi(data, endpoint);
+  const data = await datamaker.generateFromTemplateId("clr8yxrcy0001l808m70stapk", 1);
+  const result: Data[] = await datamaker.exportToApi(endpoint, data);
 
   expect(result[0]?.name).toBeDefined();
   expect(result[0]?.name).equal(data[0].name);
@@ -164,7 +164,7 @@ test('Send generated data to API endpoint defined in code', async () => {
   expect(result[0]?.createdBy).equal(data[0].createdBy);
   
   for (const entry of result) {
-    const deleteResult = await fetch(`${baseUrl}connections/${entry.id}`, {
+    const deleteResult = await fetch(`${baseUrl}/connections/${entry.id}`, {
       method: "DELETE",
       headers: headers
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,11 +151,11 @@ class DataMaker {
   /**
    * Send data to an endpoint. In parameters provide with endpoint compatible data as array of objects
    * and with API endpoint either as ID of an endpoint from your account or as an object.
-   * @param data 
    * @param api 
+   * @param data 
    * @returns 
    */
-  async exportToApi(data: object[], api: string | CustomEndpoint) {  
+  async exportToApi(api: string | CustomEndpoint, data: object[]) {  
     const url = `${this.options.baseURL}/endpoints`;
     let targetEndpoint: Endpoint | CustomEndpoint;
     let result: Array<{}> = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { DefaultQuery, Fetch } from "./core";
-import { AccountTemplate, Fields, Template, Endpoint, CustomEndpoint } from "./template";
+import { AccountTemplate, Fields, Template, Endpoint, CustomEndpoint, Data } from "./template";
 import * as Errors from "./error";
 import { readEnv } from "./utils";
 import { fetchDatamaker } from "./utils";
@@ -201,4 +201,4 @@ class DataMaker {
   };
 };
 
-export { DataMaker, ClientOptions, Fields, Template, CustomEndpoint };
+export { DataMaker, ClientOptions, Fields, Template, CustomEndpoint, Data };

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ class DataMaker {
    * @param template 
    * @returns 
    */
-  async generate(template: any) {
+  async generate(template: Template) {
     if (!template) {
       throw new Errors.DataMakerError(
         "You must provide a template to generate data."

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { DefaultQuery, Fetch } from "./core";
-import { AccountTemplate, Fields, Template } from "./template";
+import { AccountTemplate, Fields, Template, Endpoint, CustomEndpoint } from "./template";
 import * as Errors from "./error";
 import { readEnv } from "./utils";
 import { fetchDatamaker } from "./utils";
@@ -103,7 +103,7 @@ class DataMaker {
    * @param template 
    * @returns 
    */
-  async generate(template: Template) {
+  async generate(template: any) {
     if (!template) {
       throw new Errors.DataMakerError(
         "You must provide a template to generate data."
@@ -112,8 +112,7 @@ class DataMaker {
 
     if (!template.quantity) {
       template.quantity = 1;
-    };
-
+    };   
     return (await fetchDatamaker(this.options.baseURL, this.headers, template)).json(); 
   };
   /**
@@ -125,19 +124,14 @@ class DataMaker {
    */
   async generateFromTemplateId(templateId: string, quantity: number = 1) {        
     const url = `${this.options.baseURL}/templates`;
-    const headers = {
-      "Authorization": this.apiKey,
-      "Content-type": "application/json",  
-      "Credentials": "omit"   
-    };
 
     const fetchTemplate = await fetch(url, {
       method: "GET",
-        headers: headers
+        headers: this.headers
     });
 
     const templateData = await fetchTemplate.json();
-    let template = templateData.filter((temp: AccountTemplate) => temp.id === templateId);
+    let template = templateData.find((temp: AccountTemplate) => temp.id === templateId);
   
     if (!templateData) {
       throw new Errors.DataMakerError(
@@ -150,12 +144,61 @@ class DataMaker {
         "You must provide ID of a template from your account."
       );
     };
-
-    template = template[0];
+  
     template.quantity = quantity;
-    
-    return (await fetchDatamaker(this.options.baseURL, this.headers, template)).json();   
+    return (await fetchDatamaker(this.options.baseURL, this.headers, template)).json();  
+  };
+  /**
+   * Send data to an endpoint. In parameters provide with endpoint compatible data as array of objects
+   * and with API endpoint either as ID of an endpoint from your account or as an object.
+   * @param data 
+   * @param api 
+   * @returns 
+   */
+  async exportToApi(data: object[], api: string | CustomEndpoint) {  
+    const url = `${this.options.baseURL}/endpoints`;
+    let targetEndpoint: Endpoint | CustomEndpoint;
+    let result: Array<{}> = [];
+    let headers: any = this.headers;  
+
+    if (typeof api == "string") {
+      const fetchEnpoints = await fetch(url, {
+        method: "GET",
+        headers: this.headers
+      });
+  
+      const endpointData = await fetchEnpoints.json();
+      const endpoint = endpointData.find((endpoint: Endpoint) => endpoint.id === api);
+      targetEndpoint = endpoint;
+
+      if (Object.keys(endpoint.headers).length > 0) {
+        headers = endpoint.headers;
+      };    
+
+    } else {
+      targetEndpoint = api;
+      if(api.headers) {
+        headers = api.headers;
+      };      
+    };
+        
+    for (const entry of data) {
+      const apiCall = await fetch(targetEndpoint.url, {
+        method: targetEndpoint.method,
+        headers,
+        body: JSON.stringify(entry)
+      });
+
+      const callData = await apiCall.json();
+      result.push(callData);
+    };
+   
+    if (result) return result; 
+   
+    throw new Errors.DataMakerError(
+      "Something went wrong."
+    );      
   };
 };
 
-export { DataMaker, ClientOptions, Fields, Template };
+export { DataMaker, ClientOptions, Fields, Template, CustomEndpoint };

--- a/src/template.ts
+++ b/src/template.ts
@@ -390,3 +390,32 @@ export type AccountTemplate = {
   teamId: string;
   seed: null
 };
+
+export type Endpoint = {
+  id: string;
+  name: string;
+  method: string;
+  url: string;
+  headers?: object;
+  queryParams?: object;
+  createdAt: string;
+  createdBy: string;
+  teamId?: string;
+  endpointFolderId?: string | null;
+};
+
+export type Headers = {
+  Authorization: string | undefined;
+  "Content-type": string;  
+  Credentials: string;
+};
+
+export type Data = {
+  [key: string]: string | number;
+};
+
+export type CustomEndpoint = {
+  url: string;
+  method: string;
+  headers?: object;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ dotenv.config();
 
 export default defineConfig({
   test: {
-    testTimeout: 10000,
+    testTimeout: 30000,
     coverage: {
       reporter: ["text", "json", "html"],
     },


### PR DESCRIPTION
Implements method that exports data to provided endpoint. The methods takes two arguments: 
1. endpoint which can be either a string ID of an endpoint that the user has saved to his account, or custom endpoint definition provided as object
2. data, which is an array of objects that can be either generated by datamaker-js or provided by the user.